### PR TITLE
Send request refact

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Additional fields:
     password <password>, default password is ""
     datetime_name <field name>, field with DateTime value
     tz_offset <minutes>, timezone offset in minutes
+    error_response_as_unrecoverable <true>, whatever to raise unrecoverable error when the response is non success. Default is "false"
+    retryable_response_codes <array>, the list of retryable response code. Default is [503]
 <match inp>
 ```
 


### PR DESCRIPTION
1. Added new config options
* `error_response_as_unrecoverable`, whatever to raise unrecoverable error when the response is non success. Default is "false"
* `retryable_response_codes`, the list of retryable response code. Default is [503]

2. Refact work with send request. When Clickhouse is not available or we send invalid json data there is 500 status code happens and chunk was been retryable. Now this situation excluded